### PR TITLE
Fix spelling for 'analyse' and 'analyses'

### DIFF
--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -1,0 +1,3 @@
+class Analysis < ApplicationRecord
+  belongs_to :transcription  # Relation avec la transcription
+end

--- a/app/models/analyze.rb
+++ b/app/models/analyze.rb
@@ -1,3 +1,0 @@
-class Analyze < ApplicationRecord
-  belongs_to :transcription
-end

--- a/db/migrate/20250712115655_create_analyses.rb
+++ b/db/migrate/20250712115655_create_analyses.rb
@@ -1,0 +1,10 @@
+class CreateAnalyses < ActiveRecord::Migration[7.1]
+  def change
+    create_table :analyses do |t|
+      t.references :transcription, null: false, foreign_key: true
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250720073648_rename_analyzes_to_analyses.rb
+++ b/db/migrate/20250720073648_rename_analyzes_to_analyses.rb
@@ -1,0 +1,5 @@
+class RenameAnalyzesToAnalyses < ActiveRecord::Migration[7.1]
+  def change
+    rename_table :analyzes, :analyses
+  end
+end


### PR DESCRIPTION
We had a mix of American and British English for analyze/analyse. It caused troubles. Everything is now in British English