### PR TITLE
changer la taille du bouton

### DIFF
--- a/app/assets/stylesheets/components/_buttons_upgrade.scss
+++ b/app/assets/stylesheets/components/_buttons_upgrade.scss
@@ -148,6 +148,7 @@ h2.display-6 {
 // =============================================================================
 
 .gradient-button {
+  margin-bottom: 1.5rem;
   background: linear-gradient(45deg, var(--primary-blue) 0%, var(--primary-cyan) 100%) !important;
   color: var(--white) !important;
   border: none !important;
@@ -161,8 +162,9 @@ h2.display-6 {
   cursor: pointer !important;
   min-width: 100px !important;
   min-height: 50px !important;
-
+  margin-bottom: 15rem;
   pointer-events: auto !important;
+
 
   &:hover {
     transform: translateY(-2px) !important;

--- a/app/assets/stylesheets/components/_gradient_button.scss
+++ b/app/assets/stylesheets/components/_gradient_button.scss
@@ -68,6 +68,7 @@
     transition: all 0.3s ease;
     color: white;
 
+
     &:hover {
       transform: scale(1.1);
     }

--- a/app/views/transcriptions/edit.html.erb
+++ b/app/views/transcriptions/edit.html.erb
@@ -100,14 +100,13 @@
         Next
       </button>
 
-        <%= f.button :submit,
-    "Analyse",
-    class: "gradient-button",
-    data: {
-      step_form_target: "submit",
-      analysis_form_target: "submitButton",
-      action: "click->analysis-form#submitWithLoader"
-    } %>
+      <button type="button"
+              class="gradient-button"
+              data-step-form-target="submit"
+              analysis-form-target="submitButton"
+              data-action="click->analysis-form#submitWithLoader">
+        Analyse
+      </button>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Le problème n'était pas un simple changement de css.  Les boutons de navigation jouent un peu à cache-cache.  Ils sont tous sur la page de edit mais sont visible dans les différentes étapes.
Le bouton d'analyse n'était pas un véritable bouton comme les autres mais un bouton de submission de formulaire.  Ce qui se passait c'était que le formatting de simple-form prenait le dessus et écrasait les marges dans le flex box.  Ce qui avait comme résultat que le bouton Back perdait ses marges.  J'ai essayé de forcer les changements de css en ajoutant des marges mais je n'y suis pas arriver.
Ce que j'ai fait en fin de compte, c'est de reformatter le bouton Analyse comme un bouton normal.  Pour qu'il suive aussi les logique de cache-cache, j'ai du lui ajouter  data-step-form-target="submit"
J'ai testé ici en local et tout marche comme il faut.